### PR TITLE
fix(opensearch): fixes import support for opensearch 1.x

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,30 +2,27 @@
 # https://golang.org/doc/install/source#environment
 mkdir -p build && cd build
 
-VERSION=1.0.0-beta.3
-
-
-
+VERSION=1.0.0-beta.4
 
 export GOOS=darwin
 
 export GOARCH=arm64
 
-go build -o "abc-${GOARCH}-${VERSION}" -tags 'oss' ./../cmd/abc/...
+go build -o "abc-${GOARCH}-${VERSION}" ./../cmd/abc/...
 zip -r "abc-${GOOS}-${GOARCH}-${VERSION}.zip" "abc-${GOARCH}-${VERSION}"
 
 export GOARCH=amd64
 
-go build -o "abc-${VERSION}" -tags 'oss' ./../cmd/abc/...
+go build -o "abc-${VERSION}" ./../cmd/abc/...
 zip -r "abc-${GOOS}-${VERSION}.zip" "abc-${VERSION}"
 
 export GOOS=windows
 
-go build -o "abc-${VERSION}.exe"  -tags 'oss' ./../cmd/abc/...
+go build -o "abc-${VERSION}.exe" ./../cmd/abc/...
 zip -r "abc-${GOOS}-${VERSION}.zip" "abc-${VERSION}.exe"
 
 export GOOS=linux
 
 rm "abc-${VERSION}"
-go build -o "abc-${VERSION}" -tags 'oss' ./../cmd/abc/...
+go build -o "abc-${VERSION}" ./../cmd/abc/...
 zip -r "abc-${GOOS}-${VERSION}.zip" "abc-${VERSION}"

--- a/cmd/abc/appbase_version.go
+++ b/cmd/abc/appbase_version.go
@@ -7,7 +7,7 @@ import (
 	"github.com/appbaseio/abc/imports"
 )
 
-var version = "1.0.0-beta.3"
+var version = "1.0.0-beta.4"
 var variant = imports.BuildName
 
 // runVersion runs the logout command

--- a/importer/adaptor/elasticsearch/clients/v7/reader.go
+++ b/importer/adaptor/elasticsearch/clients/v7/reader.go
@@ -26,7 +26,7 @@ type Reader struct {
 }
 
 func init() {
-	constraint, _ := version.NewConstraint(">= 7.0")
+	constraint, _ := version.NewConstraint(">= 1.0")
 	clients.AddReader("v7", constraint, func(opts *clients.ClientOptions) (client.Reader, error) {
 		esOptions := []elastic.ClientOptionFunc{
 			elastic.SetURL(opts.URLs...),


### PR DESCRIPTION
This PR fixes the support for importing to an Opensearch 1.x cluster.

### Required for all PRs:

- [x] README.md updated (if needed)
- [x] Passes `gofmt` and `golint`
