### PR TITLE
feat(elasticsearch): add support for reading/writing for ES v8

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 # https://golang.org/doc/install/source#environment
 mkdir -p build && cd build
 
-VERSION=1.0.0-beta.4
+VERSION=1.0.0
 
 export GOOS=darwin
 

--- a/cmd/abc/appbase_version.go
+++ b/cmd/abc/appbase_version.go
@@ -7,7 +7,7 @@ import (
 	"github.com/appbaseio/abc/imports"
 )
 
-var version = "1.0.0-beta.4"
+var version = "1.0.0"
 var variant = imports.BuildName
 
 // runVersion runs the logout command

--- a/importer/adaptor/elasticsearch/clients/all/versions.go
+++ b/importer/adaptor/elasticsearch/clients/all/versions.go
@@ -3,4 +3,5 @@ package all
 import (
 	// ensures init functions get called
 	_ "github.com/appbaseio/abc/importer/adaptor/elasticsearch/clients/v7"
+	_ "github.com/appbaseio/abc/importer/adaptor/elasticsearch/clients/v8"
 )

--- a/importer/adaptor/elasticsearch/clients/v8/reader.go
+++ b/importer/adaptor/elasticsearch/clients/v8/reader.go
@@ -1,0 +1,144 @@
+package v8
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/appbaseio/abc/importer/adaptor/elasticsearch/clients"
+	"github.com/appbaseio/abc/importer/client"
+	"github.com/appbaseio/abc/importer/message"
+	"github.com/appbaseio/abc/importer/message/ops"
+	"github.com/appbaseio/abc/log"
+	"github.com/hashicorp/go-version"
+	"github.com/olivere/elastic/v7"
+)
+
+var _ client.Reader = &Reader{}
+
+// Reader fulfills the client.Reader interface
+type Reader struct {
+	tail      bool
+	index     string
+	logger    log.Logger
+	esClient  *elastic.Client
+	isAppbase bool
+}
+
+func init() {
+	constraint, _ := version.NewConstraint(">= 8.0")
+	clients.AddReader("v8", constraint, func(opts *clients.ClientOptions) (client.Reader, error) {
+		esOptions := []elastic.ClientOptionFunc{
+			elastic.SetURL(opts.URLs...),
+			elastic.SetSniff(false),
+			elastic.SetHttpClient(opts.HTTPClient),
+			elastic.SetMaxRetries(2),
+		}
+		if opts.UserInfo != nil {
+			if pwd, ok := opts.UserInfo.Password(); ok {
+				esOptions = append(esOptions, elastic.SetBasicAuth(opts.UserInfo.Username(), pwd))
+			}
+		}
+		esClient, err := elastic.NewClient(esOptions...)
+		if err != nil {
+			return nil, err
+		}
+		r := &Reader{}
+		r.tail = false // TODO: fix
+		r.esClient = esClient
+		r.logger = log.With("reader", "elasticsearch").With("version", 7)
+		r.index = opts.Index
+		// check appbase
+		uri := opts.URLs[0]
+		if strings.Contains(uri, "scalr.api.appbase.io") {
+			r.isAppbase = true
+		} else {
+			r.isAppbase = false
+		}
+		return r, nil
+	})
+}
+
+func (r *Reader) Read(resumeMap map[string]client.MessageSet, filterFn client.NsFilterFunc) client.MessageChanFunc {
+	return func(s client.Session, done chan struct{}) (chan client.MessageSet, error) {
+		out := make(chan client.MessageSet)
+		go func() {
+			defer close(out)
+			log.With("cluster", r.esClient).Infoln("starting Read func")
+
+			// fetch data
+			tableDone := r.iterateType(out, done)
+			func() {
+				for {
+					select {
+					case i, ok := <-tableDone:
+						if !ok {
+							return
+						}
+						r.logger.Infof("Mapping %s done", i)
+					case <-done:
+						return
+					}
+				}
+			}()
+
+			return
+		}()
+		return out, nil
+	}
+}
+
+func (r *Reader) iterateType(out chan<- client.MessageSet, done chan struct{}) <-chan string {
+	tableDone := make(chan string)
+	go func() {
+		defer close(tableDone)
+		select {
+		default:
+			const chunkSize = 1000
+			searchService, _ := r.esClient.Search(r.index).Size(chunkSize).Query(elastic.NewMatchAllQuery()).TrackTotalHits(true).Sort("_id", true).Do(context.Background())
+			hitsSize := len(searchService.Hits.Hits)
+			if hitsSize != 0 {
+				lastData := searchService.Hits.Hits[hitsSize-1]
+				currHits := int64(hitsSize)
+				for searchService.TotalHits() >= currHits {
+					if r.writeHitToFile(searchService, out) {
+						return
+					}
+					searchService, _ = r.esClient.Search(r.index).Size(chunkSize).Query(elastic.NewMatchAllQuery()).TrackTotalHits(true).SearchAfter(lastData.Id).Sort("_id", true).Do(context.Background())
+					hitsSize = len(searchService.Hits.Hits)
+					if hitsSize == 0 {
+						break
+					}
+					lastData = searchService.Hits.Hits[hitsSize-1]
+					currHits += int64(hitsSize)
+				}
+			}
+			// finish
+			tableDone <- "_doc"
+			return
+		case <-done:
+			log.With("cluster", r.esClient).Infoln("Done with iterating")
+			return
+		}
+	}()
+	return tableDone
+}
+
+func (r *Reader) writeHitToFile(searchService *elastic.SearchResult, out chan<- client.MessageSet) bool {
+	for _, hit := range searchService.Hits.Hits {
+		bytes, _ := hit.Source.MarshalJSON()
+		var m map[string]interface{}
+		err := json.Unmarshal(bytes, &m)
+		if err != nil {
+			r.logger.Errorf("Problem unmarshaling document %s", err)
+			return true
+		}
+		// r.logger.Infoln(m)
+		// send data
+		out <- client.MessageSet{
+			// _doc instead of t
+			Msg: message.From(ops.Insert, "_doc", m),
+		}
+	}
+	return false
+}

--- a/importer/adaptor/elasticsearch/clients/v8/writer_test.go
+++ b/importer/adaptor/elasticsearch/clients/v8/writer_test.go
@@ -1,0 +1,111 @@
+package v8
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/appbaseio/abc/importer/adaptor/elasticsearch/clients"
+	"github.com/appbaseio/abc/importer/client"
+	"github.com/appbaseio/abc/importer/message"
+	"github.com/appbaseio/abc/importer/message/ops"
+	"github.com/appbaseio/abc/log"
+)
+
+const (
+	defaultURL   = "http://127.0.0.1:9200"
+	defaultIndex = "test_v8"
+	testType     = "test"
+)
+
+var testURL = os.Getenv("ES_V8_URL")
+
+func fullURL(suffix string) string {
+	return fmt.Sprintf("%s/%s%s", testURL, defaultIndex, suffix)
+}
+
+func setup() error {
+	log.Debugln("setting up tests")
+	return clearTestData()
+}
+
+func clearTestData() error {
+	req, _ := http.NewRequest(http.MethodDelete, fullURL(""), nil)
+	resp, err := http.DefaultClient.Do(req)
+	log.Debugf("clearTestData response, %+v", resp)
+	return err
+}
+
+func TestMain(m *testing.M) {
+	if testURL == "" {
+		testURL = defaultURL
+	}
+
+	if err := setup(); err != nil {
+		log.Errorf("unable to setup tests, %s", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	shutdown()
+	os.Exit(code)
+}
+
+func shutdown() {
+	log.Debugln("shutting down tests")
+	clearTestData()
+	log.Debugln("tests shutdown complete")
+}
+
+type countResponse struct {
+	Count int `json:"count"`
+}
+
+func TestWriter(t *testing.T) {
+	opts := &clients.ClientOptions{
+		URLs:       []string{testURL},
+		HTTPClient: http.DefaultClient,
+		Index:      defaultIndex,
+	}
+	vc := clients.Clients["v8"]
+	w, _ := vc.Creator(opts)
+	w.Write(
+		message.WithConfirms(
+			make(chan struct{}),
+			message.From(ops.Insert, testType, map[string]interface{}{"hello": "world"})),
+	)(nil)
+	w.Write(
+		message.WithConfirms(
+			make(chan struct{}),
+			message.From(ops.Insert, testType, map[string]interface{}{"_id": "booya", "hello": "world"})),
+	)(nil)
+	w.Write(
+		message.WithConfirms(
+			make(chan struct{}),
+			message.From(ops.Update, testType, map[string]interface{}{"_id": "booya", "hello": "goodbye"})),
+	)(nil)
+	w.Write(
+		message.WithConfirms(
+			make(chan struct{}),
+			message.From(ops.Delete, testType, map[string]interface{}{"_id": "booya", "hello": "goodbye"})),
+	)(nil)
+	w.(client.Closer).Close()
+
+	if _, err := http.Get(fullURL("/_refresh")); err != nil {
+		t.Fatalf("_refresh request failed, %s", err)
+	}
+	time.Sleep(1 * time.Second)
+
+	resp, err := http.Get(fullURL("/_count"))
+	if err != nil {
+		t.Fatalf("_count request failed, %s", err)
+	}
+	defer resp.Body.Close()
+	var r countResponse
+	json.NewDecoder(resp.Body).Decode(&r)
+	if r.Count != 1 {
+		t.Errorf("mismatched doc count, expected 1, got %d", r.Count)
+	}
+}


### PR DESCRIPTION
This PR adds support for reading from and writing to an Elasticsearch v8 index.

### Required for all PRs:

- [x] README.md updated (if needed)
- [x] Passes `gofmt` and `golint`
