### PR TITLE
Add fix to properly import docs in OpenSearch newer versions

### DIFF
--- a/importer/adaptor/elasticsearch/elasticsearch.go
+++ b/importer/adaptor/elasticsearch/elasticsearch.go
@@ -314,7 +314,7 @@ func determineVersion(uri *url.URL, host string, user *url.Userinfo) (string, er
 	// will return a different version that will make abc think this is an ES 8.x
 	// cluster instead.
 	if strings.Contains(strings.ToLower(r.Tagline), "opensearch") {
-		return "8.8.1", nil
+		return "8.0.0", nil
 	}
 
 	return r.Version.Number, nil


### PR DESCRIPTION
### Required for all PRs:

- [x] README.md updated (if needed)
- [x] Passes `gofmt` and `golint`

This PR adds support for treating OpenSearch as ES 8.x instead of 7.x. Newer versions of OpenSearch do not support `_type: "doc"` which is also the behaviour of ES 8.x.

This fixes importing issues with OpenSearch.
